### PR TITLE
Prepare ec2 monitoring modules from tfvars

### DIFF
--- a/examples/monitoring/README.md
+++ b/examples/monitoring/README.md
@@ -1,0 +1,11 @@
+This example shows how to wire the `modules/monitoring` child module with values passed via a `*.tfvars` file.
+
+Files:
+- `main.tf`: Consumes the root EC2 module and attaches the monitoring child module
+- `terraform.tfvars`: Provides values for both modules
+
+Usage:
+1. Initialize: `terraform init`
+2. Plan with tfvars: `terraform plan -var-file=terraform.tfvars`
+3. Apply with tfvars: `terraform apply -var-file=terraform.tfvars`
+

--- a/examples/monitoring/USAGE.md
+++ b/examples/monitoring/USAGE.md
@@ -1,0 +1,74 @@
+How to pass most values from a tfvars file
+
+1) Prepare a tfvars file (e.g. `terraform.tfvars`) with your values. Example keys and types:
+
+```hcl
+region = "us-east-1"
+name   = "my-ec2"
+
+# EC2 basics
+ami               = null
+instance_type     = "t3.micro"
+key_name          = null
+subnet_id         = "subnet-xxxxxxxx"
+vpc_security_group_ids = ["sg-xxxxxxxx"]
+associate_public_ip_address = true
+instance_detailed_monitoring = true
+tags = {
+  Project = "my"
+  Env     = "dev"
+}
+
+# Monitoring
+alarm_name_prefix     = "my-ec2"
+create_default_alarms = true
+
+# Either create a new SNS topic
+create_sns_topic = true
+sns_topic_name   = "my-ec2-alarms"
+sns_subscriptions = [
+  { protocol = "email", endpoint = "alerts@example.com" }
+]
+
+# Or use existing
+sns_topic_arn = null
+
+default_alarm_actions = []
+
+# Custom alarms (optional)
+custom_alarms = [
+  {
+    name                = "my-ec2-network-in-high"
+    comparison_operator = "GreaterThanOrEqualToThreshold"
+    evaluation_periods  = 2
+    threshold           = 104857600
+    metric_name         = "NetworkIn"
+    namespace           = "AWS/EC2"
+    period              = 60
+    statistic           = "Sum"
+    treat_missing_data  = "missing"
+  }
+]
+
+# CloudWatch Agent via SSM (optional)
+enable_cloudwatch_agent = false
+create_ssm_association  = true
+ssm_document_name       = "AmazonCloudWatch-ManageAgent"
+cw_agent_action         = "configure"
+cw_agent_config_json    = null
+cw_agent_config_ssm_parameter_name = null
+```
+
+2) Run Terraform:
+
+```bash
+terraform init
+terraform plan -var-file=terraform.tfvars
+terraform apply -var-file=terraform.tfvars
+```
+
+Notes
+- If `default_alarm_actions` is empty and you set `create_sns_topic=true`, alarms use the created topic.
+- For EC2-related metrics, dimensions are automatically set to `InstanceId = module.ec2.id` unless you override.
+- To maximize tfvars-driven config, set all booleans, strings, lists, and objects above in your tfvars.
+

--- a/examples/monitoring/main.tf
+++ b/examples/monitoring/main.tf
@@ -1,0 +1,71 @@
+terraform {
+  required_version = ">= 1.5.7"
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 6.0"
+    }
+  }
+}
+
+provider "aws" {
+  region = var.region
+}
+
+module "ec2" {
+  source = "../.."
+
+  create = var.create
+  name   = var.name
+
+  region                   = var.region
+  ami                      = var.ami
+  instance_type            = var.instance_type
+  key_name                 = var.key_name
+  monitoring               = var.instance_detailed_monitoring
+  subnet_id                = var.subnet_id
+  vpc_security_group_ids   = var.vpc_security_group_ids
+  associate_public_ip_address = var.associate_public_ip_address
+  tags                     = var.tags
+}
+
+module "monitoring" {
+  source = "../../modules/monitoring"
+
+  create               = var.create
+  instance_id          = module.ec2.id
+  alarm_name_prefix    = var.alarm_name_prefix
+  tags                 = var.tags
+
+  # Default alarms
+  create_default_alarms = var.create_default_alarms
+  default_alarm_actions = var.default_alarm_actions
+  default_cpu           = var.default_cpu
+
+  # SNS (either create or use existing)
+  create_sns_topic  = var.create_sns_topic
+  sns_topic_name    = var.sns_topic_name
+  sns_topic_arn     = var.sns_topic_arn
+  sns_kms_master_key_id = var.sns_kms_master_key_id
+  sns_subscriptions     = var.sns_subscriptions
+
+  # Custom alarms
+  alarms = var.custom_alarms
+
+  # CloudWatch Agent via SSM Association
+  enable_cloudwatch_agent              = var.enable_cloudwatch_agent
+  create_ssm_association               = var.create_ssm_association
+  ssm_document_name                    = var.ssm_document_name
+  cw_agent_action                      = var.cw_agent_action
+  cw_agent_config_json                 = var.cw_agent_config_json
+  cw_agent_config_ssm_parameter_name   = var.cw_agent_config_ssm_parameter_name
+}
+
+output "instance_id" {
+  value = module.ec2.id
+}
+
+output "sns_topic_arn" {
+  value = module.monitoring.sns_topic_arn
+}
+

--- a/examples/monitoring/variables.tf
+++ b/examples/monitoring/variables.tf
@@ -1,0 +1,160 @@
+variable "create" {
+  type    = bool
+  default = true
+}
+
+variable "name" {
+  type    = string
+  default = "example-ec2"
+}
+
+variable "region" {
+  type = string
+}
+
+variable "ami" {
+  type    = string
+  default = null
+}
+
+variable "instance_type" {
+  type    = string
+  default = "t3.micro"
+}
+
+variable "key_name" {
+  type    = string
+  default = null
+}
+
+variable "subnet_id" {
+  type = string
+}
+
+variable "vpc_security_group_ids" {
+  type    = list(string)
+  default = []
+}
+
+variable "associate_public_ip_address" {
+  type    = bool
+  default = false
+}
+
+variable "instance_detailed_monitoring" {
+  type    = bool
+  default = true
+}
+
+variable "tags" {
+  type    = map(string)
+  default = {}
+}
+
+variable "alarm_name_prefix" {
+  type = string
+}
+
+variable "create_default_alarms" {
+  type    = bool
+  default = true
+}
+
+variable "default_alarm_actions" {
+  type    = list(string)
+  default = []
+}
+
+variable "default_cpu" {
+  type = object({
+    comparison_operator = optional(string)
+    evaluation_periods  = optional(number)
+    threshold           = optional(number)
+    period              = optional(number)
+    statistic           = optional(string)
+    treat_missing_data  = optional(string)
+  })
+  default = {}
+}
+
+variable "create_sns_topic" {
+  type    = bool
+  default = false
+}
+
+variable "sns_topic_name" {
+  type    = string
+  default = null
+}
+
+variable "sns_topic_arn" {
+  type    = string
+  default = null
+}
+
+variable "sns_kms_master_key_id" {
+  type    = string
+  default = null
+}
+
+variable "sns_subscriptions" {
+  type = list(object({
+    protocol = string
+    endpoint = string
+  }))
+  default = []
+}
+
+variable "custom_alarms" {
+  type = list(object({
+    name                        = optional(string)
+    alarm_description           = optional(string)
+    comparison_operator         = string
+    evaluation_periods          = number
+    threshold                   = number
+    metric_name                 = string
+    namespace                   = string
+    period                      = number
+    statistic                   = optional(string)
+    extended_statistic          = optional(string)
+    datapoints_to_alarm         = optional(number)
+    treat_missing_data          = optional(string)
+    unit                        = optional(string)
+    alarm_actions               = optional(list(string))
+    ok_actions                  = optional(list(string))
+    insufficient_data_actions   = optional(list(string))
+    dimensions                  = optional(map(string))
+  }))
+  default = []
+}
+
+variable "enable_cloudwatch_agent" {
+  type    = bool
+  default = false
+}
+
+variable "create_ssm_association" {
+  type    = bool
+  default = true
+}
+
+variable "ssm_document_name" {
+  type    = string
+  default = "AmazonCloudWatch-ManageAgent"
+}
+
+variable "cw_agent_action" {
+  type    = string
+  default = "configure"
+}
+
+variable "cw_agent_config_json" {
+  type    = string
+  default = null
+}
+
+variable "cw_agent_config_ssm_parameter_name" {
+  type    = string
+  default = null
+}
+

--- a/modules/monitoring/main.tf
+++ b/modules/monitoring/main.tf
@@ -1,0 +1,138 @@
+terraform {
+  required_version = ">= 1.5.7"
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 6.0"
+    }
+  }
+}
+
+locals {
+  create = var.create
+
+  topic_arn = var.create_sns_topic ? aws_sns_topic.this[0].arn : var.sns_topic_arn
+
+  default_alarm_actions = length(var.default_alarm_actions) > 0 ? var.default_alarm_actions : (
+    local.topic_arn != null ? [local.topic_arn] : []
+  )
+
+  merged_alarms = [for idx, a in var.alarms : merge(a, {
+    name = coalesce(a.name, format("%s-%s", var.alarm_name_prefix, idx))
+    alarm_actions = coalesce(a.alarm_actions, local.default_alarm_actions)
+    ok_actions    = coalesce(a.ok_actions, local.default_alarm_actions)
+    insufficient_data_actions = coalesce(a.insufficient_data_actions, [])
+    dimensions = a.dimensions == null && a.namespace == "AWS/EC2" ? {
+      InstanceId = var.instance_id
+    } : (
+      a.dimensions == null ? {} : a.dimensions
+    )
+  })]
+}
+
+resource "aws_sns_topic" "this" {
+  count = local.create && var.create_sns_topic ? 1 : 0
+
+  name              = coalesce(var.sns_topic_name, format("%s-alarms", var.alarm_name_prefix))
+  kms_master_key_id = var.sns_kms_master_key_id
+  tags              = var.tags
+}
+
+resource "aws_sns_topic_subscription" "this" {
+  for_each = local.create && var.create_sns_topic ? { for s in var.sns_subscriptions : format("%s:%s", s.protocol, s.endpoint) => s } : {}
+
+  topic_arn = aws_sns_topic.this[0].arn
+  protocol  = each.value.protocol
+  endpoint  = each.value.endpoint
+}
+
+resource "aws_cloudwatch_metric_alarm" "default" {
+  for_each = local.create && var.create_default_alarms ? {
+    "cpu_high" = {
+      alarm_name          = format("%s-cpu-high", var.alarm_name_prefix)
+      comparison_operator = var.default_cpu.comparison_operator
+      evaluation_periods  = var.default_cpu.evaluation_periods
+      threshold           = var.default_cpu.threshold
+      period              = var.default_cpu.period
+      statistic           = var.default_cpu.statistic
+      treat_missing_data  = var.default_cpu.treat_missing_data
+      metric_name         = "CPUUtilization"
+      namespace           = "AWS/EC2"
+      dimensions          = { InstanceId = var.instance_id }
+    }
+    "status_check" = {
+      alarm_name          = format("%s-status-check", var.alarm_name_prefix)
+      comparison_operator = "GreaterThanOrEqualToThreshold"
+      evaluation_periods  = 1
+      threshold           = 1
+      period              = 60
+      statistic           = "Maximum"
+      treat_missing_data  = "missing"
+      metric_name         = "StatusCheckFailed_System"
+      namespace           = "AWS/EC2"
+      dimensions          = { InstanceId = var.instance_id }
+    }
+  } : {}
+
+  alarm_name          = each.value.alarm_name
+  comparison_operator = each.value.comparison_operator
+  evaluation_periods  = each.value.evaluation_periods
+  threshold           = each.value.threshold
+  metric_name         = each.value.metric_name
+  namespace           = each.value.namespace
+  period              = each.value.period
+  statistic           = each.value.statistic
+  treat_missing_data  = each.value.treat_missing_data
+  alarm_actions       = local.default_alarm_actions
+  ok_actions          = local.default_alarm_actions
+  dimensions          = each.value.dimensions
+  tags                = var.tags
+}
+
+resource "aws_cloudwatch_metric_alarm" "custom" {
+  for_each = local.create ? { for a in local.merged_alarms : a.name => a } : {}
+
+  alarm_name                = each.value.name
+  comparison_operator       = each.value.comparison_operator
+  evaluation_periods        = each.value.evaluation_periods
+  threshold                 = each.value.threshold
+  metric_name               = each.value.metric_name
+  namespace                 = each.value.namespace
+  period                    = each.value.period
+  statistic                 = try(each.value.statistic, null)
+  extended_statistic        = try(each.value.extended_statistic, null)
+  datapoints_to_alarm       = try(each.value.datapoints_to_alarm, null)
+  treat_missing_data        = try(each.value.treat_missing_data, null)
+  alarm_description         = try(each.value.alarm_description, null)
+  unit                      = try(each.value.unit, null)
+  alarm_actions             = try(each.value.alarm_actions, local.default_alarm_actions)
+  ok_actions                = try(each.value.ok_actions, local.default_alarm_actions)
+  insufficient_data_actions = try(each.value.insufficient_data_actions, null)
+  dimensions                = try(each.value.dimensions, {})
+  tags                      = var.tags
+}
+
+# Optional: Manage CloudWatch Agent via SSM Association
+resource "aws_ssm_association" "cw_agent" {
+  count = local.create && var.enable_cloudwatch_agent && var.create_ssm_association ? 1 : 0
+
+  name = var.ssm_document_name
+
+  targets {
+    key    = "InstanceIds"
+    values = [var.instance_id]
+  }
+
+  parameters = merge(
+    var.cw_agent_config_json != null ? {
+      cw_agent_config = [var.cw_agent_config_json]
+    } : {},
+    var.cw_agent_config_ssm_parameter_name != null ? {
+      cw_agent_config_ssm_parameter_store_name = [var.cw_agent_config_ssm_parameter_name]
+    } : {},
+    {
+      action = [var.cw_agent_action]
+    },
+  )
+}
+

--- a/modules/monitoring/outputs.tf
+++ b/modules/monitoring/outputs.tf
@@ -1,0 +1,10 @@
+output "sns_topic_arn" {
+  description = "SNS topic ARN used for alarm notifications"
+  value       = try(aws_sns_topic.this[0].arn, var.sns_topic_arn)
+}
+
+output "alarm_arns" {
+  description = "ARNs of created CloudWatch alarms"
+  value       = concat([for a in aws_cloudwatch_metric_alarm.default : a.arn], [for a in aws_cloudwatch_metric_alarm.custom : a.arn])
+}
+

--- a/modules/monitoring/variables.tf
+++ b/modules/monitoring/variables.tf
@@ -1,0 +1,140 @@
+variable "create" {
+  description = "Whether to create monitoring resources"
+  type        = bool
+  default     = true
+}
+
+variable "tags" {
+  description = "Tags to apply to created resources"
+  type        = map(string)
+  default     = {}
+}
+
+variable "instance_id" {
+  description = "EC2 Instance ID that monitoring targets"
+  type        = string
+}
+
+variable "alarm_name_prefix" {
+  description = "Prefix for generated alarm names"
+  type        = string
+}
+
+variable "default_alarm_actions" {
+  description = "Default ARNs for alarm and OK actions. If empty and SNS is created or provided, will use that topic."
+  type        = list(string)
+  default     = []
+}
+
+variable "create_default_alarms" {
+  description = "Create a minimal set of default EC2 alarms (CPU high, StatusCheck)"
+  type        = bool
+  default     = true
+}
+
+variable "default_cpu" {
+  description = "Defaults for CPU high alarm"
+  type = object({
+    comparison_operator = optional(string, "GreaterThanOrEqualToThreshold")
+    evaluation_periods  = optional(number, 2)
+    threshold           = optional(number, 80)
+    period              = optional(number, 60)
+    statistic           = optional(string, "Average")
+    treat_missing_data  = optional(string, "missing")
+  })
+  default = {}
+}
+
+variable "create_sns_topic" {
+  description = "Create an SNS topic for alarms"
+  type        = bool
+  default     = false
+}
+
+variable "sns_topic_name" {
+  description = "Name of the SNS topic to create"
+  type        = string
+  default     = null
+}
+
+variable "sns_topic_arn" {
+  description = "Existing SNS topic ARN to use for alarms"
+  type        = string
+  default     = null
+}
+
+variable "sns_kms_master_key_id" {
+  description = "KMS key ID or ARN for SNS topic encryption"
+  type        = string
+  default     = null
+}
+
+variable "sns_subscriptions" {
+  description = "SNS subscriptions to attach to the created topic"
+  type = list(object({
+    protocol = string
+    endpoint = string
+  }))
+  default = []
+}
+
+variable "alarms" {
+  description = "Custom CloudWatch metric alarms to create"
+  type = list(object({
+    name                        = optional(string)
+    alarm_description           = optional(string)
+    comparison_operator         = string
+    evaluation_periods          = number
+    threshold                   = number
+    metric_name                 = string
+    namespace                   = string
+    period                      = number
+    statistic                   = optional(string)
+    extended_statistic          = optional(string)
+    datapoints_to_alarm         = optional(number)
+    treat_missing_data          = optional(string)
+    unit                        = optional(string)
+    alarm_actions               = optional(list(string))
+    ok_actions                  = optional(list(string))
+    insufficient_data_actions   = optional(list(string))
+    dimensions                  = optional(map(string))
+  }))
+  default = []
+}
+
+variable "enable_cloudwatch_agent" {
+  description = "Whether to enable CloudWatch Agent via SSM association"
+  type        = bool
+  default     = false
+}
+
+variable "create_ssm_association" {
+  description = "Create SSM association to manage CloudWatch Agent"
+  type        = bool
+  default     = true
+}
+
+variable "ssm_document_name" {
+  description = "SSM document name to apply for CloudWatch Agent"
+  type        = string
+  default     = "AmazonCloudWatch-ManageAgent"
+}
+
+variable "cw_agent_action" {
+  description = "CloudWatch Agent action for SSM doc (configure/start/stop)"
+  type        = string
+  default     = "configure"
+}
+
+variable "cw_agent_config_json" {
+  description = "CloudWatch Agent JSON config payload"
+  type        = string
+  default     = null
+}
+
+variable "cw_agent_config_ssm_parameter_name" {
+  description = "SSM Parameter Store name that contains CloudWatch Agent config JSON"
+  type        = string
+  default     = null
+}
+


### PR DESCRIPTION
Add a child Terraform module for EC2 monitoring with an example demonstrating full `tfvars` driven configuration.

The module is designed to allow nearly all configuration, including alarm details and CloudWatch Agent settings, to be passed from a tfvars file, fulfilling the user's request for maximum parameterization.

---
<a href="https://cursor.com/background-agent?bcId=bc-2f25ce1d-8956-4979-aa1b-cba5a0f3e166">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-2f25ce1d-8956-4979-aa1b-cba5a0f3e166">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

