### PR TITLE
Show wrapper output feeding monitoring

### DIFF
--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -1,0 +1,36 @@
+module "ec2" {
+  source = "./modules/ec2_wrapper"
+
+  name                 = var.instance_name
+  instance_type        = var.instance_type
+  ami                  = var.ami
+  subnet_id            = var.subnet_id
+  vpc_security_group_ids = var.vpc_security_group_ids
+  key_name             = var.key_name
+  iam_instance_profile = var.iam_instance_profile
+  user_data            = var.user_data
+  volume_size_gb       = var.volume_size_gb
+  tags                 = var.tags
+}
+
+module "monitoring" {
+  source = "./modules/monitoring"
+
+  name_prefix          = var.instance_name
+  instance_id          = module.ec2.instance_id
+  alarm_cpu_threshold  = var.alarm_cpu_threshold
+  alarm_eval_periods   = var.alarm_eval_periods
+  alarm_period_seconds = var.alarm_period_seconds
+  sns_topic_arn        = var.sns_topic_arn
+}
+
+output "instance_id" {
+  value       = module.ec2.instance_id
+  description = "ID of the EC2 instance"
+}
+
+output "instance_public_ip" {
+  value       = module.ec2.instance_public_ip
+  description = "Public IP of the EC2 instance (if assigned)"
+}
+

--- a/terraform/modules/ec2_wrapper/main.tf
+++ b/terraform/modules/ec2_wrapper/main.tf
@@ -1,0 +1,88 @@
+data "aws_caller_identity" "current" {}
+
+data "aws_region" "current" {}
+
+data "aws_ami" "al2" {
+  count       = var.ami == null ? 1 : 0
+  owners      = ["amazon"]
+  most_recent = true
+  filter {
+    name   = "name"
+    values = ["amzn2-ami-hvm-*-x86_64-gp2"]
+  }
+  filter {
+    name   = "state"
+    values = ["available"]
+  }
+}
+
+data "aws_default_vpc" "this" {}
+
+data "aws_subnets" "default" {
+  filter {
+    name   = "vpc-id"
+    values = [data.aws_default_vpc.this.id]
+  }
+}
+
+locals {
+  selected_ami    = var.ami != null ? var.ami : (length(data.aws_ami.al2) > 0 ? data.aws_ami.al2[0].id : null)
+  selected_subnet = var.subnet_id != null ? var.subnet_id : (length(data.aws_subnets.default.ids) > 0 ? data.aws_subnets.default.ids[0] : null)
+  tags_base = merge({
+    Name        = var.name
+    Environment = "dev"
+    Terraform   = "true"
+  }, var.tags)
+}
+
+resource "aws_security_group" "ssh" {
+  count       = length(var.vpc_security_group_ids) == 0 ? 1 : 0
+  name        = "${var.name}-ssh"
+  description = "Allow SSH"
+  vpc_id      = data.aws_default_vpc.this.id
+
+  ingress {
+    description = "SSH"
+    from_port   = 22
+    to_port     = 22
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  tags = local.tags_base
+}
+
+resource "aws_instance" "this" {
+  ami                         = local.selected_ami
+  instance_type               = var.instance_type
+  subnet_id                   = local.selected_subnet
+  vpc_security_group_ids      = length(var.vpc_security_group_ids) > 0 ? var.vpc_security_group_ids : (aws_security_group.ssh[*].id)
+  key_name                    = var.key_name
+  iam_instance_profile        = var.iam_instance_profile
+  user_data                   = var.user_data
+  monitoring                  = true
+
+  root_block_device {
+    volume_size = var.volume_size_gb
+    volume_type = "gp3"
+    delete_on_termination = true
+  }
+
+  tags = local.tags_base
+}
+
+output "instance_id" {
+  value = aws_instance.this.id
+}
+
+output "instance_public_ip" {
+  value = aws_instance.this.public_ip
+}
+

--- a/terraform/modules/ec2_wrapper/variables.tf
+++ b/terraform/modules/ec2_wrapper/variables.tf
@@ -1,0 +1,58 @@
+variable "name" {
+  description = "Name tag for the EC2 instance"
+  type        = string
+}
+
+variable "instance_type" {
+  description = "EC2 instance type"
+  type        = string
+}
+
+variable "ami" {
+  description = "AMI ID to use. If null, latest Amazon Linux 2 will be used"
+  type        = string
+  default     = null
+}
+
+variable "subnet_id" {
+  description = "Subnet ID to launch into. If null, default subnet will be used (if available)"
+  type        = string
+  default     = null
+}
+
+variable "vpc_security_group_ids" {
+  description = "List of security group IDs to associate. If empty, a basic SSH SG will be created"
+  type        = list(string)
+  default     = []
+}
+
+variable "key_name" {
+  description = "Name of an existing EC2 Key Pair for SSH"
+  type        = string
+  default     = null
+}
+
+variable "iam_instance_profile" {
+  description = "Name of an IAM instance profile to attach"
+  type        = string
+  default     = null
+}
+
+variable "user_data" {
+  description = "User data script (plain text)"
+  type        = string
+  default     = null
+}
+
+variable "volume_size_gb" {
+  description = "Root volume size in GB"
+  type        = number
+  default     = 8
+}
+
+variable "tags" {
+  description = "Additional tags to add to resources"
+  type        = map(string)
+  default     = {}
+}
+

--- a/terraform/modules/monitoring/main.tf
+++ b/terraform/modules/monitoring/main.tf
@@ -1,0 +1,30 @@
+locals {
+  alarm_name = "${var.name_prefix}-cpu-high"
+  alarm_desc = "CPUUtilization exceeds ${var.alarm_cpu_threshold}% for ${var.alarm_eval_periods}x${var.alarm_period_seconds}s on instance ${var.instance_id}"
+}
+
+resource "aws_cloudwatch_metric_alarm" "cpu_high" {
+  alarm_name          = local.alarm_name
+  alarm_description   = local.alarm_desc
+  comparison_operator = "GreaterThanThreshold"
+  evaluation_periods  = var.alarm_eval_periods
+  threshold           = var.alarm_cpu_threshold
+  metric_name         = "CPUUtilization"
+  namespace           = "AWS/EC2"
+  period              = var.alarm_period_seconds
+  statistic           = "Average"
+
+  dimensions = {
+    InstanceId = var.instance_id
+  }
+
+  treat_missing_data = "notBreaching"
+
+  alarm_actions = var.sns_topic_arn != null ? [var.sns_topic_arn] : []
+  ok_actions    = var.sns_topic_arn != null ? [var.sns_topic_arn] : []
+}
+
+output "alarm_name" {
+  value = aws_cloudwatch_metric_alarm.cpu_high.alarm_name
+}
+

--- a/terraform/modules/monitoring/variables.tf
+++ b/terraform/modules/monitoring/variables.tf
@@ -1,0 +1,34 @@
+variable "name_prefix" {
+  description = "Prefix used for naming monitoring resources"
+  type        = string
+}
+
+variable "instance_id" {
+  description = "EC2 instance ID to monitor"
+  type        = string
+}
+
+variable "alarm_cpu_threshold" {
+  description = "CPU utilization threshold percentage for alarm"
+  type        = number
+  default     = 80
+}
+
+variable "alarm_eval_periods" {
+  description = "Number of periods for evaluation"
+  type        = number
+  default     = 3
+}
+
+variable "alarm_period_seconds" {
+  description = "Period in seconds for each evaluation"
+  type        = number
+  default     = 60
+}
+
+variable "sns_topic_arn" {
+  description = "Optional SNS topic ARN to notify on alarm"
+  type        = string
+  default     = null
+}
+

--- a/terraform/providers.tf
+++ b/terraform/providers.tf
@@ -1,0 +1,14 @@
+terraform {
+  required_version = ">= 1.3.0"
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.0"
+    }
+  }
+}
+
+provider "aws" {
+  region = var.aws_region
+}
+

--- a/terraform/terraform.tfvars.example
+++ b/terraform/terraform.tfvars.example
@@ -1,0 +1,21 @@
+aws_region = "us-east-1"
+
+# EC2 settings (override as needed)
+instance_name             = "demo-ec2"
+instance_type             = "t3.micro"
+# ami                     = "ami-xxxxxxxx"  # optional; if omitted, AL2 latest is used
+# subnet_id               = "subnet-xxxxxxxx"  # optional; if omitted, default subnet (if any)
+# vpc_security_group_ids  = ["sg-xxxxxxxx"]    # optional; if omitted, a basic SSH SG is created
+# key_name                = "my-keypair"       # optional
+volume_size_gb            = 12
+tags = {
+  Environment = "dev"
+  Owner       = "you@example.com"
+}
+
+# Monitoring settings
+alarm_cpu_threshold  = 70
+alarm_eval_periods   = 2
+alarm_period_seconds = 60
+# sns_topic_arn       = "arn:aws:sns:us-east-1:123456789012:alerts"  # optional
+

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -1,0 +1,90 @@
+variable "aws_region" {
+  description = "AWS region to deploy resources into"
+  type        = string
+  default     = "us-east-1"
+}
+
+variable "instance_name" {
+  description = "Name tag for the EC2 instance"
+  type        = string
+  default     = "example-ec2"
+}
+
+variable "instance_type" {
+  description = "EC2 instance type"
+  type        = string
+  default     = "t3.micro"
+}
+
+variable "ami" {
+  description = "AMI ID to use. If null, latest Amazon Linux 2 will be used"
+  type        = string
+  default     = null
+}
+
+variable "subnet_id" {
+  description = "Subnet ID to launch the instance into. If null, default subnet will be used (if available)"
+  type        = string
+  default     = null
+}
+
+variable "vpc_security_group_ids" {
+  description = "List of security group IDs to associate. If empty, a basic SSH SG will be created"
+  type        = list(string)
+  default     = []
+}
+
+variable "key_name" {
+  description = "Name of an existing EC2 Key Pair for SSH"
+  type        = string
+  default     = null
+}
+
+variable "iam_instance_profile" {
+  description = "Name of an IAM instance profile to attach"
+  type        = string
+  default     = null
+}
+
+variable "user_data" {
+  description = "User data script (plain text)"
+  type        = string
+  default     = null
+}
+
+variable "volume_size_gb" {
+  description = "Root volume size in GB"
+  type        = number
+  default     = 8
+}
+
+variable "tags" {
+  description = "Additional tags to add to resources"
+  type        = map(string)
+  default     = {}
+}
+
+variable "alarm_cpu_threshold" {
+  description = "CPUUtilization threshold percentage for alarm"
+  type        = number
+  default     = 80
+}
+
+variable "alarm_eval_periods" {
+  description = "Number of evaluation periods for the CPU alarm"
+  type        = number
+  default     = 3
+}
+
+variable "alarm_period_seconds" {
+  description = "Period in seconds for collecting CPU metrics"
+  type        = number
+  default     = 60
+}
+
+variable "sns_topic_arn" {
+  description = "Optional SNS topic ARN for alarm notifications"
+  type        = string
+  default     = null
+}
+


### PR DESCRIPTION
Add a Terraform example to create an EC2 instance via a wrapper module and configure CloudWatch CPU monitoring for it.

---
<a href="https://cursor.com/background-agent?bcId=bc-c9d7e24f-4fea-419b-abc8-9ce9c147c1e0">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-c9d7e24f-4fea-419b-abc8-9ce9c147c1e0">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

